### PR TITLE
Use Port 9505, fixes #7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ MAINTAINER Thomas Boerger <thomas@webhippie.de>
 
 COPY dockerhub_exporter /bin/dockerhub_exporter
 
-EXPOSE 9105
+EXPOSE 9505
 ENTRYPOINT ["/bin/dockerhub_exporter"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage of /bin/dockerhub_exporter:
   -version
       Print version information
   -web.listen-address string
-      Address to listen on for web interface and telemetry (default ":9105")
+      Address to listen on for web interface and telemetry (default ":9505")
   -web.telemetry-path string
       Path to expose metrics of the exporter (default "/metrics")
 ```

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	showVersion = flag.Bool("version", false, "Print version information")
 
 	// listenAddress defines the local address binding for the server.
-	listenAddress = flag.String("web.listen-address", ":9105", "Address to listen on for web interface and telemetry")
+	listenAddress = flag.String("web.listen-address", ":9505", "Address to listen on for web interface and telemetry")
 
 	// metricsPath defines the path to access the metrics.
 	metricsPath = flag.String("web.telemetry-path", "/metrics", "Path to expose metrics of the exporter")


### PR DESCRIPTION
Port 9505 has been allocated at https://github.com/prometheus/prometheus/wiki/Default-port-allocations for this project.